### PR TITLE
Allow to cmake other than in repository root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(SYNC_ENABLE)
   include_directories("$(CURL_INCLUDE_DIR)")
 endif()
 
-include_directories(src)
+include_directories(${CMAKE_BINARY_DIR}/src src)
 
 file(GLOB SRC_LIST src/*.c)
 


### PR DESCRIPTION
`${CMAKE_BINARY_DIR}` is the top level of build tree, and `${CMAKE_BINARY_DIR}/src` include path is added for the configured `${CMAKE_BINARY_DIR}/src/config.h`.

----

I am not familiar with cmake, but most projects recommend to build in `build` directory, the current fails if trying to build other than in the root of repository. The change would allow the configured header to be found if building in, for example, `build`.

I also opted not to edit the instructions in README, because that (building in root) might be what @nielssp wants.